### PR TITLE
서버 통신 - users 테이블 전송 가능

### DIFF
--- a/app/src/main/java/com/example/battlerunner/network/ApiService.kt
+++ b/app/src/main/java/com/example/battlerunner/network/ApiService.kt
@@ -10,10 +10,10 @@ import retrofit2.http.POST
 
 interface ApiService {
 
-    @POST("login-info/addLoginInfo") // 서버 경로와 일치하도록 수정
+    @POST("login-info/addLoginInfo")
     suspend fun addLoginInfo(@Body loginInfo: LoginInfo): Response<Void>
 
-    @POST("users/addUser") // 서버의 UserController와 맞추기
+    @POST("users/addUser")
     suspend fun addUser(@Body user: User): Response<Void>
 
 }

--- a/app/src/main/java/com/example/battlerunner/network/RetrofitInstance.kt
+++ b/app/src/main/java/com/example/battlerunner/network/RetrofitInstance.kt
@@ -8,7 +8,6 @@ import retrofit2.converter.gson.GsonConverterFactory
 object RetrofitInstance {
     // BASE_URL은 서버의 기본 URL 설정
     // TODO URL 설정
-    //private const val BASE_URL = "http://10.0.2.2:8800/"
     private const val BASE_URL = "http://192.168.1.71:8800/"
 
     // Logging interceptor 추가

--- a/app/src/main/java/com/example/battlerunner/ui/battle/BattleFragment.kt
+++ b/app/src/main/java/com/example/battlerunner/ui/battle/BattleFragment.kt
@@ -117,7 +117,7 @@ class BattleFragment : Fragment(R.layout.fragment_battle) {
         }
     }
 
-    // Territory Capture 그리드 초기화
+    // Territory Capture 그리드 초기화 [!!그리드 그릴 때 필요한 메서드!!]
     private fun initializeMap() {
         val startLatLng = LatLng(37.5665, 126.9780) // 시작 위치 (예: 서울)
         battleViewModel.createGrid(startLatLng, 10, 10) // 10x10 그리드 생성
@@ -131,7 +131,7 @@ class BattleFragment : Fragment(R.layout.fragment_battle) {
         }
     }
 
-    // 위치 업데이트를 위한 LocationRequest와 LocationCallback 설정
+    // 위치 업데이트를 위한 LocationRequest와 LocationCallback 설정 [!!그리드 그릴 때 필요한 메서드!!]
 //    private fun initializeLocationUpdates() {
 //        val locationRequest = LocationRequest.Builder(
 //            Priority.PRIORITY_HIGH_ACCURACY,
@@ -166,7 +166,7 @@ class BattleFragment : Fragment(R.layout.fragment_battle) {
         homeViewModel.stopTimer() // 타이머 정지
     }
 
-    // Polygon.contains 확장 함수 정의
+    // Polygon.contains 확장 함수 정의 [!!그리드 그릴 때 필요한 메서드!!]
     private fun Polygon.contains(point: LatLng): Boolean {
         val vertices = this.points
         var contains = false


### PR DESCRIPTION
MAP 관련 수정
ㅇ custom 현재 위치 버튼 수정 (왜 안 될까..)

[서버 통신]
users 테이블 전송 가능(완료)
[프론트]
배틀프래그먼트에서 시작 버튼을 누르면 홈프래그먼트 맵에 경로 그리기(완료)
카메라 위치 저장 변수 삭제(완료)
러닝 경로 기록 (완료)
다른 프래그먼트로 이동하더라도 프래그먼트 종료x (완료)
 ㄴ홈에서 배틀 갔다가 다시 홈에 와도 다시 내 위치가 되게끔
내 위치 로드 느림 (완료)
*custom 현재 위치 버튼 (완료했었으나 다른 부분 고치다가 안 되게 됨...)
기본 위치 버튼 숨김 (완료)